### PR TITLE
Alternative Python multiprocessing implementation

### DIFF
--- a/python/annealing.py
+++ b/python/annealing.py
@@ -6,6 +6,7 @@ def T_anneal(T, ii, num_steps, num_burnin):
 
     return float(T_a)
 
+
 def B_anneal(B, ii, num_steps, num_burnin):
 
     #implement annealing code here

--- a/python/ising.py
+++ b/python/ising.py
@@ -8,7 +8,9 @@ try:
 except:
     from tqdm import tqdm
 
-def run_ising(N,T,num_steps,num_burnin,flip_prop,J,B,disable_tqdm=False):
+
+def run_ising(N, T, num_steps, num_burnin, flip_prop, J, B,
+              disable_tqdm=False):
 
     # Description of parameters:
     # N = Grid Size
@@ -22,15 +24,15 @@ def run_ising(N,T,num_steps,num_burnin,flip_prop,J,B,disable_tqdm=False):
     # flip_prop = Total ratio of spins to possibly flip per step
 
     # Initialize variables
-    M,E = 0,0 # Magnetization and Energy Initial Values
-    Msamp, Esamp = [],[] #Arrays to hold magnetization and energy values
+    M, E = 0, 0  # Magnetization and Energy Initial Values
+    Msamp, Esamp = [], []  #Arrays to hold magnetization and energy values
 
     # We obtain the sum of nearest neighbors by convoluting
     #   this matrix with the spin matrix
     conv_mat = np.matrix('0 1 0; 1 0 1; 0 1 0')
 
     # Generate a random initial configuration
-    spin = np.random.choice([-1,1],(N,N))
+    spin = np.random.choice([-1, 1], (N, N))
 
     try:
         __IPYTHON__
@@ -51,34 +53,41 @@ def run_ising(N,T,num_steps,num_burnin,flip_prop,J,B,disable_tqdm=False):
                 pass
             else:
                 steps.set_description("Working on T = %.2f" % T)
-                steps.refresh() # to show immediately the update
+                steps.refresh()  # to show immediately the update
 
         #implement annealing in annealing.py file
         T_step = T_anneal(T, step, num_steps, num_burnin)
         B_step = B_anneal(B, step, num_steps, num_burnin)
 
         #Calculating the total spin of neighbouring cells
-        neighbors = signal.convolve2d(spin,conv_mat,mode='same',boundary='wrap')
+        neighbors = signal.convolve2d(
+            spin, conv_mat, mode='same', boundary='wrap')
 
         #Sum up our variables of interest, normalize by N^2
-        M = float(np.sum(spin))/float(N**2)
+        M = float(np.sum(spin)) / float(N**2)
         Msamp.append(M)
 
         #Divide by two because of double counting
-        E = float(-J*(np.sum((spin*neighbors)))/2.0)/float(N**2) - float(B_step)*M
+        E = float(-J * (np.sum(
+            (spin * neighbors))) / 2.0) / float(N**2) - float(B_step) * M
         Esamp.append(E)
 
         #Calculate the change in energy of flipping a spin
-        DeltaE = 2.0 * (J*(spin*neighbors) + float(B_step)*spin)
+        DeltaE = 2.0 * (J * (spin * neighbors) + float(B_step) * spin)
 
         #Calculate the transition
-        p_trans = np.where(DeltaE >= 0.0, np.exp(-1.0*DeltaE/float(T_step)),1.0)
+        p_trans = np.where(DeltaE >= 0.0,
+                           np.exp(-1.0 * DeltaE / float(T_step)), 1.0)
         #If DeltaE is positive, calculate the Boltzman flipping probability.
         #If not, assign a transition probability of 1
 
         #Decide which transitions will occur
-        transitions = [[-1 if (cell>random.random() and flip_prop>random.random()) else 1 for cell in row] for row in p_trans]
+        transitions = [[
+            -1
+            if (cell > random.random() and flip_prop > random.random()) else 1
+            for cell in row
+        ] for row in p_trans]
         #Perform the transitions
-        spin = spin*transitions
+        spin = spin * transitions
 
     return Msamp, Esamp, spin

--- a/python/main-multiprocessing.py
+++ b/python/main-multiprocessing.py
@@ -6,175 +6,245 @@ import click
 import numpy as np
 import logging
 import matplotlib.pyplot as plt
-from ising import run_ising #import run_ising function from ising.py
+from ising import run_ising  #import run_ising function from ising.py
 import multiprocessing as mp
+from IsingLattice import IsingLattice
+from functools import partial
+from math import ceil
 
-def run_simulation(index,temp,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename,data_listener,corr_listener):
-    print("Working on Temp {0}".format(round(temp,3)))
+
+def run_simulation(temp, n, num_steps, num_burnin, num_analysis, flip_prop, j,
+                   b):
+
     try:
         #run the Ising model
-        Msamp, Esamp, spin = run_ising(n,temp,num_steps,num_burnin,flip_prop,j,b,disable_tqdm=True)
 
-        try:
-            #calculate statistical values
-            M_mean = np.average(Msamp[-num_analysis:])
-            E_mean = np.average(Esamp[-num_analysis:])
-            M_std = np.std(Msamp[-num_analysis:])
-            E_std = np.std(Esamp[-num_analysis:])
+        lattice = IsingLattice(n, flip_prop)
 
-            data_array = [np.abs(M_mean),M_std,E_mean,E_std]
-            data_listener.put([temp]+data_array)
+        Msamp, Esamp = run_ising(
+            lattice, temp, num_steps, num_burnin, j, b, disable_tqdm=True)
 
-            corr = compute_autocorrelation(spin)
-            [corr_listener.put([temp]+corr_value) for corr_value in corr]
+        # calculate statistical values
+        M_mean = np.average(Msamp[-num_analysis:])
+        E_mean = np.average(Esamp[-num_analysis:])
+        M_std = np.std(Msamp[-num_analysis:])
+        E_std = np.std(Esamp[-num_analysis:])
+        cv = (1 / (temp * temp)) * (E_std**2)
+        chi = (1 / temp) * (M_std**2)
 
-            print("Done with Temp {0}".format(round(temp,3)))
-            return True
+        data_array = [np.abs(M_mean), M_std, E_mean, E_std, cv, chi]
 
-        except:
-            logging.error("Temp="+str(round(temp,3))+": Statistical Calculation Failed. No Data Written.")
-            return False
+        corr = lattice.calc_auto_correlation()
+        lattice.free_memory()
+
+        return [temp, data_array, corr]
 
     except KeyboardInterrupt:
         print("\n\nProgram Terminated. Good Bye!")
-        data_listener.put('kill')
-        corr_listener.put('kill')
         sys.exit()
 
-    except:
-        logging.error("Temp="+str(round(temp,3))+": Simulation Failed. No Data Written")
+    # except:
+    #     logging.error("Temp="+str(temp)+": Simulation Failed. No Data Written")
 
-#simulation options (enter python main.py --help for details)
+
+# Simulation options (enter python main.py --help for details)
 @click.command()
-@click.option('--t_min', default=2.0, prompt='Minimum Temp', help='Minimum Temperature (inclusive)', type=float)
-@click.option('--t_max', default=2.6, prompt='Maximum Temp', help='Maximum Temperature (inclusive)', type=float)
-@click.option('--t_step', default=0.1, prompt='Temp Step Size', help='Temperature Step Size', type=float)
+@click.option(
+    '--t_min',
+    default=2.0,
+    prompt='Minimum Temp',
+    help='Minimum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_max',
+    default=2.6,
+    prompt='Maximum Temp',
+    help='Maximum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_step',
+    default=0.1,
+    prompt='Temp Step Size',
+    help='Temperature Step Size',
+    type=float)
+@click.option(
+    '--n', prompt='Lattice Size', help='Lattice Size (NxN)', type=int)
+@click.option(
+    '--num_steps', default=100000, help='Total Number of Steps', type=int)
+@click.option(
+    '--num_analysis',
+    default=50000,
+    help='Number of Steps used in Analysis',
+    type=int)
+@click.option(
+    '--num_burnin',
+    default=25000,
+    help='Total Number of Burnin Steps',
+    type=int)
+@click.option('--j', default=1.0, help='Interaction Strength', type=float)
+@click.option('--b', default=0.0, help='Applied Magnetic Field', type=float)
+@click.option(
+    '--flip_prop',
+    default=0.1,
+    help='Proportion of Spins to Consider Flipping per Step',
+    type=float)
+@click.option(
+    '--output',
+    default='data',
+    help='Directory Name for Data Output',
+    type=str)
+@click.option('--processes', default=mp.cpu_count(), help='', type=int)
+def main(t_min, t_max, t_step, n, num_steps, num_analysis, num_burnin, j, b,
+         flip_prop, output, processes):
+    simulation_start_time = time.time()
 
-@click.option('--n', prompt='Lattice Size', help='Lattice Size (NxN)',type=int)
-@click.option('--num_steps', default=100000, help='Total Number of Steps',type=int)
-@click.option('--num_analysis', default=50000, help='Number of Steps used in Analysis',type=int)
-@click.option('--num_burnin', default=0, help='Total Number of Burnin Steps',type=int)
+    data_filename, corr_filename = initialize_simulation(
+        n, num_steps, num_analysis, num_burnin, output, j, b, flip_prop)
 
-@click.option('--j', default=1.0, help='Interaction Strength',type=float)
-@click.option('--b', default=0.0, help='Applied Magnetic Field',type=float)
-@click.option('--flip_prop', default=0.1, help='Proportion of Spins to Consider Flipping per Step',type=float)
+    run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin,
+                  num_analysis, flip_prop, j, b, data_filename, corr_filename)
 
-@click.option('--output', default='data', help='Directory Name for Data Output',type=str)
+    simulation_duration = round((time.time() - simulation_start_time) / 60.0,
+                                2)
 
-def main(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,flip_prop,output):
-    data_filename, corr_filename = initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_prop)
-    run_processes(t_min,t_max,t_step,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename)
-    print('\n\nSimulation Finished! Data written to '+ data_filename)
+    print(
+        '\n\nSimulation finished in {0} minutes. Data written to {1}.'.format(
+            simulation_duration, data_filename))
 
-def initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_prop):
+    return None
+
+
+def initialize_simulation(n, num_steps, num_analysis, num_burnin, output, j, b,
+                          flip_prop):
     check_step_values(num_steps, num_analysis, num_burnin)
     data_filename, corr_filename = get_filenames(output)
-    write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop)
-    print('\nSimulation Started! Data will be written to ' + data_filename + '\n')
+    write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop)
+    print('\nSimulation Started! Data will be written to ' + data_filename +
+          '\n')
     return data_filename, corr_filename
 
-def check_step_values(num_steps,num_analysis,num_burnin): #simulation size checks and exceptions
-    if (num_burnin > num_steps):
-        raise ValueError('num_burning cannot be greater than available num_steps. Exiting simulation.')
-        sys.exit()
 
-    if (num_analysis > num_steps - num_burnin):
-        raise ValueError('num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.')
-        sys.exit()
+def check_step_values(num_steps, num_analysis,
+                      num_burnin):  #simulation size checks and exceptions
+    if num_burnin > num_steps:
+        raise ValueError(
+            'num_burnin cannot be greater than available num_steps. Exiting simulation.'
+        )
 
-def get_filenames(dirname): #make data folder if doesn't exist, then specify filename
+    if num_analysis > (num_steps - num_burnin):
+        raise ValueError(
+            'num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.'
+        )
+
+
+def get_filenames(
+        dirname):  #make data folder if doesn't exist, then specify filename
     try:
         if not os.path.exists(dirname):
             os.makedirs(dirname)
-        data_filename = os.path.join(dirname,'data_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
-        corr_filename = os.path.join(dirname,'corr_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
+        data_filename = os.path.join(
+            dirname, 'data_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
+        corr_filename = os.path.join(
+            dirname, 'corr_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
         #Write simulation parameters to file
         return data_filename, corr_filename
     except:
         raise ValueError('Directory name not valid. Exiting simulation.')
-        sys.exit()
 
-def get_temp_array(t_min,t_max,t_step):
-    if (t_min > t_max):
-        raise ValueError('T_min cannot be greater than T_max. Exiting Simulation')
-        sys.exit()
-    try:
-        T = np.arange(t_min,t_max,t_step).tolist()
+
+def get_temp_array(t_min, t_max, t_step):
+    if t_min > t_max:
+        raise ValueError(
+            'T_min cannot be greater than T_max. Exiting Simulation')
+    elif (t_max - t_min) < t_step:
+        return [t_min]
+    else:
+        # Pure Python replacement to deal with numpy.arange's bad handling of floating point round-off
+        n_steps = int(ceil((float(t_max) - float(t_min)) / float(t_step)))
+        T = [t_min + t_step * float(x) for x in range(0, n_steps)]
         return T
-    except:
-        raise ValueError('Error creating temperature array. Exiting simulation.')
-        sys.exit()
 
-def write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop):
+
+def write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop):
     try:
-        with open(data_filename,'w') as csv_file:
+        with open(data_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
-            #Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+            # Write simulations parameters to CSV file
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
-        with open(corr_filename,'w') as csv_file:
+
+        with open(corr_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
-            #Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+
+            # Write simulations parameters to CSV file
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
     except:
-        logging.error('Could not save simulation parameters. Exiting simulation')
+        logging.error(
+            'Could not save simulation parameters. Exiting simulation')
         sys.exit()
 
-def compute_autocorrelation(spin):
-    n = len(spin)
-    corr_array = []
-    for k in range(1,int(n/2)):
-        col_mean, row_mean = spin.mean(axis=0),spin.mean(axis=1)
-        #compute r values for rows and cols
-        r_col = [np.multiply(spin[j,:]-col_mean,spin[(j+k)%n,:]-col_mean) for j in range(1,n)]
-        r_row = [np.multiply(spin[:,j]-row_mean,spin[:,(j+k)%n]-row_mean) for j in range(1,n)]
-        #normalize r values
-        r_col = np.divide(r_col,float(n))
-        r_row = np.divide(r_row,float(n))
-        #calculate corr for k and add it to array
-        corr = (r_col.mean() + r_row.mean())/2.0
-        corr_array.append([k,corr])
-    return corr_array
 
-def listener(q, fn):
-    '''listens for messages on the q, writes to file. '''
-    f = open(fn, 'a') 
-    writer = csv.writer(f, delimiter=',', lineterminator='\n')
-    while 1:
-        m = q.get()
-        if m == 'kill':
-            break
-        writer.writerow(m)
-        f.flush()
-    f.close()
+def append_data_to_file(filename, data_array, temp=False):
+    try:
+        with open(filename, 'a') as csv_file:  # Appends to existing CSV File
+            writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
+            if temp:
+                writer.writerow([temp] + data_array)
+            else:
+                writer.writerow(data_array)
+    except:
+        logging.error("Temp={0}: Error Writing to File".format(temp))
 
-def run_processes(t_min,t_max,t_step,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename):
-    
+
+def run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin,
+                  num_analysis, flip_prop, j, b, data_filename, corr_filename):
+
+    # Get the temperature array
     T = get_temp_array(t_min, t_max, t_step)
-    
-    #must use Manager queue here, or will not work
-    manager = mp.Manager()
-    data_listener = manager.Queue()
-    corr_listener = manager.Queue()    
-    pool = mp.Pool(mp.cpu_count())
 
-    #put listener to work first
-    data_watcher = pool.apply_async(listener, args=(data_listener, data_filename,))
-    corr_watcher = pool.apply_async(listener, args=(corr_listener, corr_filename,))
+    # Freeze the simulation function
+    simfun = partial(
+        run_simulation,
+        n=n,
+        num_steps=num_steps,
+        num_burnin=num_burnin,
+        num_analysis=num_analysis,
+        flip_prop=flip_prop,
+        j=j,
+        b=b)
 
-    #fire off workers 
-    jobs = [pool.apply_async(run_simulation, args=(index,temp,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename,data_listener,corr_listener,)) for index,temp in enumerate(T)]
+    # Run in parallel
+    with mp.Pool(processes=processes) as pool:
+        result = pool.map(simfun, T)
 
-    # collect results from the workers through the pool result queue   
-    [job.get() for job in jobs]
+    # Save the data
+    [
+        append_data_to_file(data_filename, data_array, temp)
+        for temp, data_array, _ in result
+    ]
+    [[
+        append_data_to_file(corr_filename, corr_value, temp)
+        for corr_value in corr
+    ] for temp, _, corr in result]
 
-    #now we are done, kill the listener
-    data_listener.put('kill')
-    corr_listener.put('kill')
-    pool.close()
+    # Return none
+    return None
+
 
 if __name__ == "__main__":
-   main()
+    main()

--- a/python/main.py
+++ b/python/main.py
@@ -6,38 +6,52 @@ import click
 import numpy as np
 import logging
 import matplotlib.pyplot as plt
-from tqdm import tqdm #fancy progress bar generator
-from ising import run_ising #import run_ising function from ising.py
+from tqdm import tqdm  #fancy progress bar generator
+from ising import run_ising  #import run_ising function from ising.py
 
-def calculate_and_save_values(Msamp,Esamp,spin,num_analysis,index,temp,data_filename,corr_filename):
+
+def calculate_and_save_values(Msamp, Esamp, spin, num_analysis, index, temp,
+                              data_filename, corr_filename):
     try:
         #calculate statistical values
         M_mean = np.average(Msamp[-num_analysis:])
         E_mean = np.average(Esamp[-num_analysis:])
         M_std = np.std(Msamp[-num_analysis:])
         E_std = np.std(Esamp[-num_analysis:])
-        data_array = [np.abs(M_mean),M_std,E_mean,E_std]
+        data_array = [np.abs(M_mean), M_std, E_mean, E_std]
 
         #write data to CSV file
-        header_array = ['Temperature','Magnetizatio n Mean','Magnetization Std Dev','Energy Mean','Energy Std Dev']
-        append_data_to_file(data_filename, header_array) if index == 0 else None
+        header_array = [
+            'Temperature', 'Magnetizatio n Mean', 'Magnetization Std Dev',
+            'Energy Mean', 'Energy Std Dev'
+        ]
+        append_data_to_file(data_filename,
+                            header_array) if index == 0 else None
         append_data_to_file(data_filename, data_array, temp)
 
         #get correlation function
         corr = compute_autocorrelation(spin)
 
         #write correlation function to CSV file
-        header_array = ['Temperature','K','Spatial Spin Correlation']
-        append_data_to_file(corr_filename, header_array) if index == 0 else None
-        [append_data_to_file(corr_filename, corr_value, temp) for corr_value in corr]
+        header_array = ['Temperature', 'K', 'Spatial Spin Correlation']
+        append_data_to_file(corr_filename,
+                            header_array) if index == 0 else None
+        [
+            append_data_to_file(corr_filename, corr_value, temp)
+            for corr_value in corr
+        ]
 
         return True
 
     except:
-        logging.error("Temp="+str(temp)+": Statistical Calculation Failed. No Data Written.")
+        logging.error("Temp=" + str(temp) +
+                      ": Statistical Calculation Failed. No Data Written.")
         return False
 
-def run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,flip_prop,data_filename,corr_filename,plots):
+
+def run_simulation(t_min, t_max, t_step, n, num_steps, num_analysis,
+                   num_burnin, j, b, flip_prop, data_filename, corr_filename,
+                   plots):
 
     T = get_temp_array(t_min, t_max, t_step)
 
@@ -45,7 +59,7 @@ def run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,fl
         #initialize vars for plotting values
         temp_arr, M_mean_arr, E_mean_arr, M_std_arr, E_std_arr = [],[],[],[],[]
 
-    temp_range = tqdm(T) #set fancy progress bar range
+    temp_range = tqdm(T)  #set fancy progress bar range
     for index, temp in enumerate(temp_range):
 
         #show current temperature
@@ -53,13 +67,24 @@ def run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,fl
 
         try:
             #run the Ising model
-            Msamp, Esamp, spin = run_ising(n,temp,num_steps,num_burnin,flip_prop,j,b,disable_tqdm=False)
+            Msamp, Esamp, spin = run_ising(
+                n,
+                temp,
+                num_steps,
+                num_burnin,
+                flip_prop,
+                j,
+                b,
+                disable_tqdm=False)
             #get and save statistical values
-            if calculate_and_save_values(Msamp,Esamp,spin,num_analysis,index,temp,data_filename,corr_filename):
+            if calculate_and_save_values(Msamp, Esamp, spin, num_analysis,
+                                         index, temp, data_filename,
+                                         corr_filename):
 
                 if plots:
                     #for plotting
-                    M_mean, E_mean, M_std, E_std = get_plot_values(temp,Msamp,Esamp,num_analysis)
+                    M_mean, E_mean, M_std, E_std = get_plot_values(
+                        temp, Msamp, Esamp, num_analysis)
                     temp_arr.append(temp)
                     M_mean_arr.append(M_mean)
                     E_mean_arr.append(E_mean)
@@ -71,42 +96,84 @@ def run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,fl
             sys.exit()
 
         except:
-            logging.error("Temp="+str(temp)+": Simulation Failed. No Data Written")
+            logging.error(
+                "Temp=" + str(temp) + ": Simulation Failed. No Data Written")
 
     if plots:
         plot_graphs(temp_arr, M_mean_arr, M_std_arr, E_mean_arr, E_std_arr)
 
+
 #simulation options (enter python main.py --help for details)
 @click.command()
-@click.option('--t_min', default=2.0, prompt='Minimum Temp', help='Minimum Temperature (inclusive)', type=float)
-@click.option('--t_max', default=2.6, prompt='Maximum Temp', help='Maximum Temperature (inclusive)', type=float)
-@click.option('--t_step', default=0.1, prompt='Temp Step Size', help='Temperature Step Size', type=float)
+@click.option(
+    '--t_min',
+    default=2.0,
+    prompt='Minimum Temp',
+    help='Minimum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_max',
+    default=2.6,
+    prompt='Maximum Temp',
+    help='Maximum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_step',
+    default=0.1,
+    prompt='Temp Step Size',
+    help='Temperature Step Size',
+    type=float)
+@click.option(
+    '--n', prompt='Lattice Size', help='Lattice Size (NxN)', type=int)
+@click.option(
+    '--num_steps', default=100000, help='Total Number of Steps', type=int)
+@click.option(
+    '--num_analysis',
+    default=50000,
+    help='Number of Steps used in Analysis',
+    type=int)
+@click.option(
+    '--num_burnin', default=0, help='Total Number of Burnin Steps', type=int)
+@click.option('--j', default=1.0, help='Interaction Strength', type=float)
+@click.option('--b', default=0.0, help='Applied Magnetic Field', type=float)
+@click.option(
+    '--flip_prop',
+    default=0.1,
+    help='Proportion of Spins to Consider Flipping per Step',
+    type=float)
+@click.option(
+    '--output',
+    default='data',
+    help='Directory Name for Data Output',
+    type=str)
+@click.option(
+    '--plots',
+    default=True,
+    help='Turn Automatic Plot Creation Off or On',
+    type=bool)
+def main(t_min, t_max, t_step, n, num_steps, num_analysis, num_burnin, j, b,
+         flip_prop, output, plots):
+    data_filename, corr_filename = initialize_simulation(
+        n, num_steps, num_analysis, num_burnin, output, j, b, flip_prop)
+    run_simulation(t_min, t_max, t_step, n, num_steps, num_analysis,
+                   num_burnin, j, b, flip_prop, data_filename, corr_filename,
+                   plots)
+    print('\n\nSimulation Finished! Data written to ' + data_filename)
 
-@click.option('--n', prompt='Lattice Size', help='Lattice Size (NxN)',type=int)
-@click.option('--num_steps', default=100000, help='Total Number of Steps',type=int)
-@click.option('--num_analysis', default=50000, help='Number of Steps used in Analysis',type=int)
-@click.option('--num_burnin', default=0, help='Total Number of Burnin Steps',type=int)
 
-@click.option('--j', default=1.0, help='Interaction Strength',type=float)
-@click.option('--b', default=0.0, help='Applied Magnetic Field',type=float)
-@click.option('--flip_prop', default=0.1, help='Proportion of Spins to Consider Flipping per Step',type=float)
-
-@click.option('--output', default='data', help='Directory Name for Data Output',type=str)
-@click.option('--plots', default=True, help='Turn Automatic Plot Creation Off or On',type=bool)
-
-def main(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,flip_prop,output,plots):
-    data_filename, corr_filename = initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_prop)
-    run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,flip_prop,data_filename,corr_filename,plots)
-    print('\n\nSimulation Finished! Data written to '+ data_filename)
-
-def initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_prop):
+def initialize_simulation(n, num_steps, num_analysis, num_burnin, output, j, b,
+                          flip_prop):
     check_step_values(num_steps, num_analysis, num_burnin)
     data_filename, corr_filename = get_filenames(output)
-    write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop)
-    print('\nSimulation Started! Data will be written to ' + data_filename + '\n')
+    write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop)
+    print('\nSimulation Started! Data will be written to ' + data_filename +
+          '\n')
     return data_filename, corr_filename
 
-def get_plot_values(temp,Msamp,Esamp,num_analysis): #only for plotting at end
+
+def get_plot_values(temp, Msamp, Esamp,
+                    num_analysis):  #only for plotting at end
     try:
         M_mean = np.average(Msamp[-num_analysis:])
         E_mean = np.average(Esamp[-num_analysis:])
@@ -117,10 +184,18 @@ def get_plot_values(temp,Msamp,Esamp,num_analysis): #only for plotting at end
         logging.error("Temp={0}: Error getting plot values".format(temp))
         return False
 
-def plot_graphs(temp_arr,M_mean_arr,M_std_arr,E_mean_arr,E_std_arr): #plot graphs at end
+
+def plot_graphs(temp_arr, M_mean_arr, M_std_arr, E_mean_arr,
+                E_std_arr):  #plot graphs at end
     plt.figure(1)
-    plt.ylim(0,1)
-    plt.errorbar(temp_arr, np.absolute(M_mean_arr), yerr=M_std_arr, uplims=True, lolims=True,fmt='o')
+    plt.ylim(0, 1)
+    plt.errorbar(
+        temp_arr,
+        np.absolute(M_mean_arr),
+        yerr=M_std_arr,
+        uplims=True,
+        lolims=True,
+        fmt='o')
     plt.xlabel('Temperature')
     plt.ylabel('Magnetization')
     plt.figure(2)
@@ -129,83 +204,118 @@ def plot_graphs(temp_arr,M_mean_arr,M_std_arr,E_mean_arr,E_std_arr): #plot graph
     plt.ylabel('Energy')
     plt.show()
 
-def check_step_values(num_steps,num_analysis,num_burnin): #simulation size checks and exceptions
+
+def check_step_values(num_steps, num_analysis,
+                      num_burnin):  #simulation size checks and exceptions
     if (num_burnin > num_steps):
-        raise ValueError('num_burning cannot be greater than available num_steps. Exiting simulation.')
+        raise ValueError(
+            'num_burning cannot be greater than available num_steps. Exiting simulation.'
+        )
         sys.exit()
 
     if (num_analysis > num_steps - num_burnin):
-        raise ValueError('num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.')
+        raise ValueError(
+            'num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.'
+        )
         sys.exit()
 
-def get_filenames(dirname): #make data folder if doesn't exist, then specify filename
+
+def get_filenames(
+        dirname):  #make data folder if doesn't exist, then specify filename
     try:
         if not os.path.exists(dirname):
             os.makedirs(dirname)
-        data_filename = os.path.join(dirname,'data_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
-        corr_filename = os.path.join(dirname,'corr_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
+        data_filename = os.path.join(
+            dirname, 'data_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
+        corr_filename = os.path.join(
+            dirname, 'corr_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
         #Write simulation parameters to file
         return data_filename, corr_filename
     except:
         raise ValueError('Directory name not valid. Exiting simulation.')
         sys.exit()
 
-def write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop):
+
+def write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop):
     try:
-        with open(data_filename,'w') as csv_file:
+        with open(data_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             #Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
-        with open(corr_filename,'w') as csv_file:
+        with open(corr_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             #Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
     except:
-        logging.error('Could not save simulation parameters. Exiting simulation')
+        logging.error(
+            'Could not save simulation parameters. Exiting simulation')
         sys.exit()
 
-def get_temp_array(t_min,t_max,t_step):
+
+def get_temp_array(t_min, t_max, t_step):
     if (t_min > t_max):
-        raise ValueError('T_min cannot be greater than T_max. Exiting Simulation')
+        raise ValueError(
+            'T_min cannot be greater than T_max. Exiting Simulation')
         sys.exit()
     try:
-        T = np.arange(t_min,t_max,t_step).tolist()
+        T = np.arange(t_min, t_max, t_step).tolist()
         return T
     except:
-        raise ValueError('Error creating temperature array. Exiting simulation.')
+        raise ValueError(
+            'Error creating temperature array. Exiting simulation.')
         sys.exit()
+
 
 def compute_autocorrelation(spin):
     n = len(spin)
     corr_array = []
-    for k in range(1,int(n/2)):
-        col_mean, row_mean = spin.mean(axis=0),spin.mean(axis=1)
+    for k in range(1, int(n / 2)):
+        col_mean, row_mean = spin.mean(axis=0), spin.mean(axis=1)
         #compute r values for rows and cols
-        r_col = [np.multiply(spin[j,:]-col_mean,spin[(j+k)%n,:]-col_mean) for j in range(1,n)]
-        r_row = [np.multiply(spin[:,j]-row_mean,spin[:,(j+k)%n]-row_mean) for j in range(1,n)]
+        r_col = [
+            np.multiply(spin[j, :] - col_mean, spin[(j + k) % n, :] - col_mean)
+            for j in range(1, n)
+        ]
+        r_row = [
+            np.multiply(spin[:, j] - row_mean, spin[:, (j + k) % n] - row_mean)
+            for j in range(1, n)
+        ]
         #normalize r values
-        r_col = np.divide(r_col,float(n))
-        r_row = np.divide(r_row,float(n))
+        r_col = np.divide(r_col, float(n))
+        r_row = np.divide(r_row, float(n))
         #calculate corr for k and add it to array
-        corr = (r_col.mean() + r_row.mean())/2.0
-        corr_array.append([k,corr])
+        corr = (r_col.mean() + r_row.mean()) / 2.0
+        corr_array.append([k, corr])
     return corr_array
 
-def append_data_to_file(filename,data_array,temp=False):
+
+def append_data_to_file(filename, data_array, temp=False):
     try:
-        with open(filename,'a') as csv_file: #appends to existing CSV File
+        with open(filename, 'a') as csv_file:  #appends to existing CSV File
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             if temp:
-                writer.writerow([temp]+data_array)
+                writer.writerow([temp] + data_array)
             else:
                 writer.writerow(data_array)
 
     except:
         logging.error("Temp={0}: Error Writing to File".format(temp))
+
 
 if __name__ == "__main__":
     print("\n2D Ising Model Simulation\n")

--- a/python_with_c/IsingLattice.py
+++ b/python_with_c/IsingLattice.py
@@ -2,11 +2,11 @@ import numpy as np
 from ctypes import *
 libc = CDLL("./ising_lattice_lib.so")
 
-libc.newMatrix.restype  = c_void_p
+libc.newMatrix.restype = c_void_p
 libc.newMatrix.argtypes = [c_int, c_int]
 
-libc.step.argtypes        = [ c_void_p, c_float, c_float ]
-libc.nsteps.argtypes      = [ c_void_p, c_int, c_float, c_float ]
+libc.step.argtypes = [c_void_p, c_float, c_float]
+libc.nsteps.argtypes = [c_void_p, c_int, c_float, c_float]
 
 libc.get_E.restype = c_float
 libc.get_M.restype = c_float
@@ -14,60 +14,78 @@ libc.auto_correlation.restype = c_float
 
 libc.auto_correlation.restype = c_float
 
+
 class IsingLattice(object):
     def __init__(self, N, flip_prop):
-        n_flip = N*N*flip_prop
+        n_flip = N * N * flip_prop
         self.N = N
         if n_flip != int(n_flip):
             n_flip = int(n_flip) + 1
-        self.matrix_ptr = c_void_p(libc.newMatrix(int(N),int(n_flip)))
+        self.matrix_ptr = c_void_p(libc.newMatrix(int(N), int(n_flip)))
         self.auto_correlation = []
+
     def free_memory(self):
         # print ('deleting ising_lattice_lib object')
-        libc.delMatrix( self.matrix_ptr ) 
+        libc.delMatrix(self.matrix_ptr)
+
     def step(self, T, B):
         return libc.step(self.matrix_ptr, c_float(T), c_float(B))
+
     def nsteps(self, T, B, n):
-        return libc.nsteps(self.matrix_ptr,n,T,B)
+        return libc.nsteps(self.matrix_ptr, n, T, B)
+
     def get_E(self):
-        return float( libc.get_E(self.matrix_ptr) )
+        return float(libc.get_E(self.matrix_ptr))
+
     def get_M(self):
-        return float( libc.get_M(self.matrix_ptr) )
+        return float(libc.get_M(self.matrix_ptr))
+
     def calc_auto_correlation(self):
         libc.calc_auto_correlation(self.matrix_ptr)
-        for i in range(1,int(self.N/2)):
+        for i in range(1, int(self.N / 2)):
             val = libc.auto_correlation(self.matrix_ptr, i)
-            self.auto_correlation.append([i,val])
+            self.auto_correlation.append([i, val])
         return self.auto_correlation
-    def set_Nflip(self,npick):
-        return  libc.set_Npick(self.matrix_ptr, c_int(npick))
-    def set_flip_prop(self,flip_prop):
-        n_flip = self.N*flip_prop
+
+    def set_Nflip(self, npick):
+        return libc.set_Npick(self.matrix_ptr, c_int(npick))
+
+    def set_flip_prop(self, flip_prop):
+        n_flip = self.N * flip_prop
         if n_flip != int(n_flip):
             n_flip = int(n_flip) + 1
         else:
             n_flip = int(n_flip)
         return (libc.set_Npick(self.matrix_ptr, c_int(n_flip)))
+
     def get_Nspin(self):
         return libc.get_Nspin(self.matrix_ptr)
+
     def get_Nalign(self):
         return libc.get_Nbond(self.matrix_ptr)
+
     def get_spin(self, i, j):
         return libc.get_spin(self.matrix_ptr, i, j)
+
     def set_spin(self, i, j, k):
         return libc.set_spin(self.matrix_ptr, i, j, k)
+
     def print_spins(self):
         return libc.print_spins(self.matrix_ptr)
+
     def print_aligned(self):
         return libc.print_bonds(self.matrix_ptr)
+
     def randomize_spins(self):
         return libc.initialize_spins(self.matrix_ptr)
+
     def get_numpy_spin_matrix(self):
         matrix = np.ones((self.N, self.N))
         for i in range(self.N):
             for j in range(self.N):
-                matrix[i,j] = libc.get_spin(self.matrix_ptr,i,j)
+                matrix[i, j] = libc.get_spin(self.matrix_ptr, i, j)
         return matrix
+
 
 if __name__ == '__main__':
     from sys import argv
@@ -75,31 +93,31 @@ if __name__ == '__main__':
     if len(argv) == 1:
         pass
     elif argv[1] == "1":
-        lattice = IsingLattice(n,.1)
+        lattice = IsingLattice(n, .1)
         lattice.print_spins()
         print("----")
         for i in range(n):
             for j in range(n):
                 continue
-                lattice.set_spin(i,j,1)
+                lattice.set_spin(i, j, 1)
         lattice.print_spins()
-        print("Nspin : %i"%lattice.get_Nspin())
-        print(" This is mag: %f"%lattice.get_M())
+        print("Nspin : %i" % lattice.get_Nspin())
+        print(" This is mag: %f" % lattice.get_M())
         print("auto_corr:")
         x = lattice.calc_auto_correlation()
         for val in x:
             print(val)
         lattice.free_memory()
-        
+
     elif argv[1] == "0":
-        lattice = IsingLattice(5,.1)
+        lattice = IsingLattice(5, .1)
         print(argv[0])
         lattice.print_spins()
         print('---')
-        lattice.set_spin(0,0,1)
+        lattice.set_spin(0, 0, 1)
         lattice.print_spins()
         print('---')
-        lattice.set_spin(0,0,-1)
+        lattice.set_spin(0, 0, -1)
         lattice.print_spins()
         print('---')
 
@@ -108,19 +126,19 @@ if __name__ == '__main__':
             for j in range(n):
                 flip = not flip
                 if flip:
-                    lattice.set_spin(i,j,1)
+                    lattice.set_spin(i, j, 1)
                 else:
-                    lattice.set_spin(i,j,-1)
+                    lattice.set_spin(i, j, -1)
         lattice.print_spins()
         print('---')
 
         lattice.free_memory()
     else:
-        lattice = IsingLattice(10,.01)
+        lattice = IsingLattice(10, .01)
         lattice.print_spins()
         print('---')
         lattice.print_aligned()
-        lattice.nsteps(8.,0.1,10000)
+        lattice.nsteps(8., 0.1, 10000)
         print('---')
         lattice.print_spins()
         print('---')
@@ -128,20 +146,20 @@ if __name__ == '__main__':
 
         lattice.randomize_spins()
         # lattice.nsteps(100,2.2,3.0)
-        print('E: ',lattice.get_E())
-        print('M: ',lattice.get_M())
+        print('E: ', lattice.get_E())
+        print('M: ', lattice.get_M())
         print('autocorrelation ', lattice.calc_auto_correlation())
         print("set_Nflip:      ", lattice.set_Nflip(20))
-        print("get_Nspin:      " , lattice.get_Nspin())
-        print("get_Nalign:     " , lattice.get_Nalign())
-        print("nsteps:         " , lattice.nsteps(2.9,1.0,10000))
-        print("set_flip_prop   " , lattice.set_flip_prop(0.20))
-        print("nsteps:         " , lattice.nsteps(2.9,1.0,20000))
-        print("step:         " , lattice.step(2.9,1.0))
-        print("get_Nspin:      " , lattice.get_Nspin())
-        print("get_Nalign:     " , lattice.get_Nalign())
-        print('E: ',lattice.get_E())
-        print("N               " , lattice.N)
+        print("get_Nspin:      ", lattice.get_Nspin())
+        print("get_Nalign:     ", lattice.get_Nalign())
+        print("nsteps:         ", lattice.nsteps(2.9, 1.0, 10000))
+        print("set_flip_prop   ", lattice.set_flip_prop(0.20))
+        print("nsteps:         ", lattice.nsteps(2.9, 1.0, 20000))
+        print("step:         ", lattice.step(2.9, 1.0))
+        print("get_Nspin:      ", lattice.get_Nspin())
+        print("get_Nalign:     ", lattice.get_Nalign())
+        print('E: ', lattice.get_E())
+        print("N               ", lattice.N)
         lattice.print_aligned()
         lattice.free_memory()
     exit(1)

--- a/python_with_c/annealing.py
+++ b/python_with_c/annealing.py
@@ -6,10 +6,11 @@ def T_anneal(T, ii, num_steps, num_burnin):
 
     return float(T_a)
 
+
 def B_anneal(B, ii, num_steps, num_burnin):
 
     #implement annealing code here
-    
+
     B_a = B
 
     return float(B_a)

--- a/python_with_c/ising_c.py
+++ b/python_with_c/ising_c.py
@@ -7,7 +7,8 @@ try:
 except:
     from tqdm import tqdm
 
-def run_ising(lattice, T,num_steps,num_burnin,J,B,disable_tqdm=False):
+
+def run_ising(lattice, T, num_steps, num_burnin, J, B, disable_tqdm=False):
 
     # Description of parameters:
     # N = Grid Size
@@ -21,8 +22,8 @@ def run_ising(lattice, T,num_steps,num_burnin,J,B,disable_tqdm=False):
     # flip_prop = Total ratio of spins to possibly flip per step
 
     # Initialize variables
-    M,E = 0,0 # Magnetization and Energy Initial Values
-    Msamp, Esamp = [],[] #Arrays to hold magnetization and energy values
+    M, E = 0, 0  # Magnetization and Energy Initial Values
+    Msamp, Esamp = [], []  #Arrays to hold magnetization and energy values
     lattice.randomize_spins()
 
     try:
@@ -43,7 +44,7 @@ def run_ising(lattice, T,num_steps,num_burnin,J,B,disable_tqdm=False):
                 pass
             else:
                 steps.set_description("Working on T = %.2f" % T)
-                steps.refresh() # to show immediately the update
+                steps.refresh()  # to show immediately the update
 
         #implement annealing in annealing.py file
 
@@ -52,7 +53,7 @@ def run_ising(lattice, T,num_steps,num_burnin,J,B,disable_tqdm=False):
 
         lattice.step(T_step, B_step)
 
-        Msamp.append( lattice.get_M() )
-        Esamp.append( lattice.get_E() )
+        Msamp.append(lattice.get_M())
+        Esamp.append(lattice.get_E())
 
     return Msamp, Esamp

--- a/python_with_c/main-multiprocessing_c.py
+++ b/python_with_c/main-multiprocessing_c.py
@@ -9,70 +9,71 @@ import matplotlib.pyplot as plt
 from ising_c import run_ising #import run_ising function from ising.py
 import multiprocessing as mp
 from IsingLattice import IsingLattice
+from functools import partial
+from math import ceil
 
-def run_simulation(index,temp,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename,data_listener,corr_listener):
-    print("Working on Temp {0}".format(round(temp,4)))
+
+def run_simulation(temp,n,num_steps,num_burnin,num_analysis,flip_prop,j,b):
+
     try:
         #run the Ising model
+
         lattice = IsingLattice(n, flip_prop)
-        time_start = time.time()
+
         Msamp, Esamp = run_ising(lattice,temp,num_steps,num_burnin,j,b,disable_tqdm=True)
 
-        try:
-            #calculate statistical values
-            M_mean = np.average(Msamp[-num_analysis:])
-            E_mean = np.average(Esamp[-num_analysis:])
-            M_std = np.std(Msamp[-num_analysis:])
-            E_std = np.std(Esamp[-num_analysis:])
+        # calculate statistical values
+        M_mean = np.average(Msamp[-num_analysis:])
+        E_mean = np.average(Esamp[-num_analysis:])
+        M_std = np.std(Msamp[-num_analysis:])
+        E_std = np.std(Esamp[-num_analysis:])
+        cv = (1 / (temp * temp)) * (E_std ** 2)
+        chi = (1 / temp) * (M_std ** 2)
 
-            data_array = [np.abs(M_mean),M_std,E_mean,E_std]
-            data_listener.put([temp]+data_array)
+        data_array = [np.abs(M_mean), M_std, E_mean, E_std, cv, chi]
 
-            corr = lattice.calc_auto_correlation()
-            lattice.free_memory()
-            [corr_listener.put([temp]+corr_value) for corr_value in corr]
+        corr = lattice.calc_auto_correlation()
+        lattice.free_memory()
 
-            print("Done with Temp {0} in {1} seconds".format(round(temp,4), round(time.time()-time_start,2)))
-            return True
-
-        except:
-            logging.error("Temp="+str(temp)+": Statistical Calculation Failed. No Data Written.")
-            return False
+        return [temp, data_array, corr]
 
     except KeyboardInterrupt:
         print("\n\nProgram Terminated. Good Bye!")
-        data_listener.put('kill')
-        corr_listener.put('kill')
         sys.exit()
 
-    except:
-        logging.error("Temp="+str(temp)+": Simulation Failed. No Data Written")
+    # except:
+    #     logging.error("Temp="+str(temp)+": Simulation Failed. No Data Written")
 
-#simulation options (enter python main.py --help for details)
+
+# Simulation options (enter python main.py --help for details)
 @click.command()
 @click.option('--t_min', default=2.0, prompt='Minimum Temp', help='Minimum Temperature (inclusive)', type=float)
 @click.option('--t_max', default=2.6, prompt='Maximum Temp', help='Maximum Temperature (inclusive)', type=float)
 @click.option('--t_step', default=0.1, prompt='Temp Step Size', help='Temperature Step Size', type=float)
-
 @click.option('--n', prompt='Lattice Size', help='Lattice Size (NxN)',type=int)
 @click.option('--num_steps', default=100000, help='Total Number of Steps',type=int)
 @click.option('--num_analysis', default=50000, help='Number of Steps used in Analysis',type=int)
 @click.option('--num_burnin', default=25000, help='Total Number of Burnin Steps',type=int)
-
 @click.option('--j', default=1.0, help='Interaction Strength',type=float)
 @click.option('--b', default=0.0, help='Applied Magnetic Field',type=float)
 @click.option('--flip_prop', default=0.1, help='Proportion of Spins to Consider Flipping per Step',type=float)
-
 @click.option('--output', default='data', help='Directory Name for Data Output',type=str)
-
-@click.option('--processes', default=1, help='',type=int)
-
-def main(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,flip_prop,output,processes):
+@click.option('--processes', default=mp.cpu_count(), help='',type=int)
+def main(t_min, t_max, t_step, n, num_steps, num_analysis, num_burnin, j, b, flip_prop, output, processes):
     simulation_start_time = time.time()
-    data_filename, corr_filename = initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_prop)
-    run_processes(processes,t_min,t_max,t_step,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename)
-    simulation_duration = round((time.time() - simulation_start_time)/60.0,2)
-    print('\n\nSimulation finished in {0} minutes. Data written to {1}.'.format(simulation_duration,data_filename))
+
+    data_filename, corr_filename = initialize_simulation(n, num_steps, num_analysis, num_burnin, output, j, b,
+                                                         flip_prop)
+
+    run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin, num_analysis, flip_prop, j, b,
+                  data_filename, corr_filename)
+
+    simulation_duration = round((time.time() - simulation_start_time) / 60.0, 2)
+
+    print('\n\nSimulation finished in {0} minutes. Data written to {1}.'.format(simulation_duration, data_filename))
+
+    return None
+
 
 def initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_prop):
     check_step_values(num_steps, num_analysis, num_burnin)
@@ -81,12 +82,14 @@ def initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_pr
     print('\nSimulation Started! Data will be written to ' + data_filename + '\n')
     return data_filename, corr_filename
 
-def check_step_values(num_steps,num_analysis,num_burnin): #simulation size checks and exceptions
-    if (num_burnin > num_steps):
-        raise ValueError('num_burning cannot be greater than available num_steps. Exiting simulation.')
 
-    if (num_analysis > num_steps - num_burnin):
+def check_step_values(num_steps,num_analysis,num_burnin): #simulation size checks and exceptions
+    if num_burnin > num_steps:
+        raise ValueError('num_burnin cannot be greater than available num_steps. Exiting simulation.')
+
+    if num_analysis > (num_steps - num_burnin):
         raise ValueError('num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.')
+
 
 def get_filenames(dirname): #make data folder if doesn't exist, then specify filename
     try:
@@ -98,36 +101,53 @@ def get_filenames(dirname): #make data folder if doesn't exist, then specify fil
         return data_filename, corr_filename
     except:
         raise ValueError('Directory name not valid. Exiting simulation.')
-        sys.exit()
+
 
 def get_temp_array(t_min,t_max,t_step):
     if (t_min > t_max):
         raise ValueError('T_min cannot be greater than T_max. Exiting Simulation')
-        sys.exit()
     try:
-        T = np.arange(t_min,t_max,t_step).tolist()
+        # Nasty replacement to deal with numpy.arange's bad handling of floating point round-off
+        n_steps = int(ceil((float(t_max) - float(t_min))/float(t_step)))
+        T = np.linspace(t_min, t_max, n_steps).tolist()
         return T
+
     except:
         raise ValueError('Error creating temperature array. Exiting simulation.')
-        sys.exit()
+
 
 def write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop):
     try:
         with open(data_filename,'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
-            #Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+            # Write simulations parameters to CSV file
+            writer.writerow(['Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis', 'Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
+            writer.writerow([n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
+
         with open(corr_filename,'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
-            #Write simulations parameters to CSV file
+
+            # Write simulations parameters to CSV file
             writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+            writer.writerow([n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
     except:
         logging.error('Could not save simulation parameters. Exiting simulation')
         sys.exit()
+
+
+def append_data_to_file(filename,data_array,temp=False):
+    try:
+        with open(filename,'a') as csv_file: # Appends to existing CSV File
+            writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
+            if temp:
+                writer.writerow([temp]+data_array)
+            else:
+                writer.writerow(data_array)
+    except:
+        logging.error("Temp={0}: Error Writing to File".format(temp))
+
 
 def compute_autocorrelation(spin):
     n = len(spin)
@@ -145,42 +165,29 @@ def compute_autocorrelation(spin):
         corr_array.append([k,corr])
     return corr_array
 
-def listener(q, fn):
-    '''listens for messages on the q, writes to file. '''
-    f = open(fn, 'a') 
-    writer = csv.writer(f, delimiter=',', lineterminator='\n')
-    while 1:
-        m = q.get()
-        if m == 'kill':
-            break
-        writer.writerow(m)
-        f.flush()
-    f.close()
 
-def run_processes(processes,t_min,t_max,t_step,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename):
-    
+def run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin, num_analysis, flip_prop, j, b,
+                  data_filename, corr_filename):
+
+    # Get the temperature array
     T = get_temp_array(t_min, t_max, t_step)
-    
-    #must use Manager queue here, or will not work
-    manager = mp.Manager()
-    data_listener = manager.Queue()
-    corr_listener = manager.Queue()    
-    pool = mp.Pool(mp.cpu_count() + 2)
 
-    #put listener to work first
-    data_watcher = pool.apply_async(listener, args=(data_listener, data_filename,))
-    corr_watcher = pool.apply_async(listener, args=(corr_listener, corr_filename,))
+    # Freeze the simulation function
+    simfun = partial(run_simulation, n=n,
+                     num_steps=num_steps, num_burnin=num_burnin, num_analysis=num_analysis,
+                     flip_prop=flip_prop, j=j, b=b)
 
-    #fire off workers 
-    jobs = [pool.apply_async(run_simulation, args=(index,temp,n,num_steps,num_burnin,num_analysis,flip_prop,j,b,data_filename,corr_filename,data_listener,corr_listener,)) for index,temp in enumerate(T)]
+    # Run in parallel
+    with mp.Pool(processes=processes) as pool:
+        result = pool.map(simfun, T)
 
-    # collect results from the workers through the pool result queue   
-    [job.get() for job in jobs]
+    # Save the data
+    [append_data_to_file(data_filename, data_array, temp) for temp, data_array, _ in result]
+    [[append_data_to_file(corr_filename, corr_value, temp) for corr_value in corr] for temp, _, corr in result]
 
-    #now we are done, kill the listener
-    data_listener.put('kill')
-    corr_listener.put('kill')
-    pool.close()
+    # Return none
+    return None
+
 
 if __name__ == "__main__":
-   main()
+    main()

--- a/python_with_c/main-multiprocessing_c.py
+++ b/python_with_c/main-multiprocessing_c.py
@@ -6,29 +6,31 @@ import click
 import numpy as np
 import logging
 import matplotlib.pyplot as plt
-from ising_c import run_ising #import run_ising function from ising.py
+from ising_c import run_ising  #import run_ising function from ising.py
 import multiprocessing as mp
 from IsingLattice import IsingLattice
 from functools import partial
 from math import ceil
 
 
-def run_simulation(temp,n,num_steps,num_burnin,num_analysis,flip_prop,j,b):
+def run_simulation(temp, n, num_steps, num_burnin, num_analysis, flip_prop, j,
+                   b):
 
     try:
         #run the Ising model
 
         lattice = IsingLattice(n, flip_prop)
 
-        Msamp, Esamp = run_ising(lattice,temp,num_steps,num_burnin,j,b,disable_tqdm=True)
+        Msamp, Esamp = run_ising(
+            lattice, temp, num_steps, num_burnin, j, b, disable_tqdm=True)
 
         # calculate statistical values
         M_mean = np.average(Msamp[-num_analysis:])
         E_mean = np.average(Esamp[-num_analysis:])
         M_std = np.std(Msamp[-num_analysis:])
         E_std = np.std(Esamp[-num_analysis:])
-        cv = (1 / (temp * temp)) * (E_std ** 2)
-        chi = (1 / temp) * (M_std ** 2)
+        cv = (1 / (temp * temp)) * (E_std**2)
+        chi = (1 / temp) * (M_std**2)
 
         data_array = [np.abs(M_mean), M_std, E_mean, E_std, cv, chi]
 
@@ -47,125 +49,198 @@ def run_simulation(temp,n,num_steps,num_burnin,num_analysis,flip_prop,j,b):
 
 # Simulation options (enter python main.py --help for details)
 @click.command()
-@click.option('--t_min', default=2.0, prompt='Minimum Temp', help='Minimum Temperature (inclusive)', type=float)
-@click.option('--t_max', default=2.6, prompt='Maximum Temp', help='Maximum Temperature (inclusive)', type=float)
-@click.option('--t_step', default=0.1, prompt='Temp Step Size', help='Temperature Step Size', type=float)
-@click.option('--n', prompt='Lattice Size', help='Lattice Size (NxN)',type=int)
-@click.option('--num_steps', default=100000, help='Total Number of Steps',type=int)
-@click.option('--num_analysis', default=50000, help='Number of Steps used in Analysis',type=int)
-@click.option('--num_burnin', default=25000, help='Total Number of Burnin Steps',type=int)
-@click.option('--j', default=1.0, help='Interaction Strength',type=float)
-@click.option('--b', default=0.0, help='Applied Magnetic Field',type=float)
-@click.option('--flip_prop', default=0.1, help='Proportion of Spins to Consider Flipping per Step',type=float)
-@click.option('--output', default='data', help='Directory Name for Data Output',type=str)
-@click.option('--processes', default=mp.cpu_count(), help='',type=int)
-def main(t_min, t_max, t_step, n, num_steps, num_analysis, num_burnin, j, b, flip_prop, output, processes):
+@click.option(
+    '--t_min',
+    default=2.0,
+    prompt='Minimum Temp',
+    help='Minimum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_max',
+    default=2.6,
+    prompt='Maximum Temp',
+    help='Maximum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_step',
+    default=0.1,
+    prompt='Temp Step Size',
+    help='Temperature Step Size',
+    type=float)
+@click.option(
+    '--n', prompt='Lattice Size', help='Lattice Size (NxN)', type=int)
+@click.option(
+    '--num_steps', default=100000, help='Total Number of Steps', type=int)
+@click.option(
+    '--num_analysis',
+    default=50000,
+    help='Number of Steps used in Analysis',
+    type=int)
+@click.option(
+    '--num_burnin',
+    default=25000,
+    help='Total Number of Burnin Steps',
+    type=int)
+@click.option('--j', default=1.0, help='Interaction Strength', type=float)
+@click.option('--b', default=0.0, help='Applied Magnetic Field', type=float)
+@click.option(
+    '--flip_prop',
+    default=0.1,
+    help='Proportion of Spins to Consider Flipping per Step',
+    type=float)
+@click.option(
+    '--output',
+    default='data',
+    help='Directory Name for Data Output',
+    type=str)
+@click.option('--processes', default=mp.cpu_count(), help='', type=int)
+def main(t_min, t_max, t_step, n, num_steps, num_analysis, num_burnin, j, b,
+         flip_prop, output, processes):
     simulation_start_time = time.time()
 
-    data_filename, corr_filename = initialize_simulation(n, num_steps, num_analysis, num_burnin, output, j, b,
-                                                         flip_prop)
+    data_filename, corr_filename = initialize_simulation(
+        n, num_steps, num_analysis, num_burnin, output, j, b, flip_prop)
 
-    run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin, num_analysis, flip_prop, j, b,
-                  data_filename, corr_filename)
+    run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin,
+                  num_analysis, flip_prop, j, b, data_filename, corr_filename)
 
-    simulation_duration = round((time.time() - simulation_start_time) / 60.0, 2)
+    simulation_duration = round((time.time() - simulation_start_time) / 60.0,
+                                2)
 
-    print('\n\nSimulation finished in {0} minutes. Data written to {1}.'.format(simulation_duration, data_filename))
+    print(
+        '\n\nSimulation finished in {0} minutes. Data written to {1}.'.format(
+            simulation_duration, data_filename))
 
     return None
 
 
-def initialize_simulation(n,num_steps,num_analysis,num_burnin,output,j,b,flip_prop):
+def initialize_simulation(n, num_steps, num_analysis, num_burnin, output, j, b,
+                          flip_prop):
     check_step_values(num_steps, num_analysis, num_burnin)
     data_filename, corr_filename = get_filenames(output)
-    write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop)
-    print('\nSimulation Started! Data will be written to ' + data_filename + '\n')
+    write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop)
+    print('\nSimulation Started! Data will be written to ' + data_filename +
+          '\n')
     return data_filename, corr_filename
 
 
-def check_step_values(num_steps,num_analysis,num_burnin): #simulation size checks and exceptions
+def check_step_values(num_steps, num_analysis,
+                      num_burnin):  #simulation size checks and exceptions
     if num_burnin > num_steps:
-        raise ValueError('num_burnin cannot be greater than available num_steps. Exiting simulation.')
+        raise ValueError(
+            'num_burnin cannot be greater than available num_steps. Exiting simulation.'
+        )
 
     if num_analysis > (num_steps - num_burnin):
-        raise ValueError('num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.')
+        raise ValueError(
+            'num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.'
+        )
 
 
-def get_filenames(dirname): #make data folder if doesn't exist, then specify filename
+def get_filenames(
+        dirname):  #make data folder if doesn't exist, then specify filename
     try:
         if not os.path.exists(dirname):
             os.makedirs(dirname)
-        data_filename = os.path.join(dirname,'data_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
-        corr_filename = os.path.join(dirname,'corr_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
+        data_filename = os.path.join(
+            dirname, 'data_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
+        corr_filename = os.path.join(
+            dirname, 'corr_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
         #Write simulation parameters to file
         return data_filename, corr_filename
     except:
         raise ValueError('Directory name not valid. Exiting simulation.')
 
 
-def get_temp_array(t_min,t_max,t_step):
+def get_temp_array(t_min, t_max, t_step):
     if t_min > t_max:
-        raise ValueError('T_min cannot be greater than T_max. Exiting Simulation')
+        raise ValueError(
+            'T_min cannot be greater than T_max. Exiting Simulation')
     elif (t_max - t_min) < t_step:
         return [t_min]
     else:
         # Pure Python replacement to deal with numpy.arange's bad handling of floating point round-off
-        n_steps = int(ceil((float(t_max) - float(t_min))/float(t_step)))
+        n_steps = int(ceil((float(t_max) - float(t_min)) / float(t_step)))
         T = [t_min + t_step * float(x) for x in range(0, n_steps)]
         return T
 
 
-def write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop):
+def write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop):
     try:
-        with open(data_filename,'w') as csv_file:
+        with open(data_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             # Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis', 'Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
 
-        with open(corr_filename,'w') as csv_file:
+        with open(corr_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
 
             # Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
     except:
-        logging.error('Could not save simulation parameters. Exiting simulation')
+        logging.error(
+            'Could not save simulation parameters. Exiting simulation')
         sys.exit()
 
 
-def append_data_to_file(filename,data_array,temp=False):
+def append_data_to_file(filename, data_array, temp=False):
     try:
-        with open(filename,'a') as csv_file: # Appends to existing CSV File
+        with open(filename, 'a') as csv_file:  # Appends to existing CSV File
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             if temp:
-                writer.writerow([temp]+data_array)
+                writer.writerow([temp] + data_array)
             else:
                 writer.writerow(data_array)
     except:
         logging.error("Temp={0}: Error Writing to File".format(temp))
 
 
-def run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin, num_analysis, flip_prop, j, b,
-                  data_filename, corr_filename):
+def run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin,
+                  num_analysis, flip_prop, j, b, data_filename, corr_filename):
 
     # Get the temperature array
     T = get_temp_array(t_min, t_max, t_step)
 
     # Freeze the simulation function
-    simfun = partial(run_simulation, n=n,
-                     num_steps=num_steps, num_burnin=num_burnin, num_analysis=num_analysis,
-                     flip_prop=flip_prop, j=j, b=b)
+    simfun = partial(
+        run_simulation,
+        n=n,
+        num_steps=num_steps,
+        num_burnin=num_burnin,
+        num_analysis=num_analysis,
+        flip_prop=flip_prop,
+        j=j,
+        b=b)
 
     # Run in parallel
     with mp.Pool(processes=processes) as pool:
         result = pool.map(simfun, T)
 
     # Save the data
-    [append_data_to_file(data_filename, data_array, temp) for temp, data_array, _ in result]
-    [[append_data_to_file(corr_filename, corr_value, temp) for corr_value in corr] for temp, _, corr in result]
+    [
+        append_data_to_file(data_filename, data_array, temp)
+        for temp, data_array, _ in result
+    ]
+    [[
+        append_data_to_file(corr_filename, corr_value, temp)
+        for corr_value in corr
+    ] for temp, _, corr in result]
 
     # Return none
     return None

--- a/python_with_c/main-multiprocessing_c.py
+++ b/python_with_c/main-multiprocessing_c.py
@@ -104,16 +104,15 @@ def get_filenames(dirname): #make data folder if doesn't exist, then specify fil
 
 
 def get_temp_array(t_min,t_max,t_step):
-    if (t_min > t_max):
+    if t_min > t_max:
         raise ValueError('T_min cannot be greater than T_max. Exiting Simulation')
-    try:
-        # Nasty replacement to deal with numpy.arange's bad handling of floating point round-off
+    elif (t_max - t_min) < t_step:
+        return [t_min]
+    else:
+        # Pure Python replacement to deal with numpy.arange's bad handling of floating point round-off
         n_steps = int(ceil((float(t_max) - float(t_min))/float(t_step)))
-        T = np.linspace(t_min, t_max, n_steps).tolist()
+        T = [t_min + t_step * float(x) for x in range(0, n_steps)]
         return T
-
-    except:
-        raise ValueError('Error creating temperature array. Exiting simulation.')
 
 
 def write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop):
@@ -147,23 +146,6 @@ def append_data_to_file(filename,data_array,temp=False):
                 writer.writerow(data_array)
     except:
         logging.error("Temp={0}: Error Writing to File".format(temp))
-
-
-def compute_autocorrelation(spin):
-    n = len(spin)
-    corr_array = []
-    for k in range(1,int(n/2)):
-        col_mean, row_mean = spin.mean(axis=0),spin.mean(axis=1)
-        #compute r values for rows and cols
-        r_col = [np.multiply(spin[j,:]-col_mean,spin[(j+k)%n,:]-col_mean) for j in range(1,n)]
-        r_row = [np.multiply(spin[:,j]-row_mean,spin[:,(j+k)%n]-row_mean) for j in range(1,n)]
-        #normalize r values
-        r_col = np.divide(r_col,float(n))
-        r_row = np.divide(r_row,float(n))
-        #calculate corr for k and add it to array
-        corr = (r_col.mean() + r_row.mean())/2.0
-        corr_array.append([k,corr])
-    return corr_array
 
 
 def run_processes(processes, t_min, t_max, t_step, n, num_steps, num_burnin, num_analysis, flip_prop, j, b,

--- a/python_with_c/main_c.py
+++ b/python_with_c/main_c.py
@@ -7,10 +7,12 @@ import numpy as np
 import logging
 import matplotlib.pyplot as plt
 from IsingLattice import IsingLattice
-from tqdm import tqdm #fancy progress bar generator
-from ising_c import run_ising #import run_ising function from ising.py
+from tqdm import tqdm  #fancy progress bar generator
+from ising_c import run_ising  #import run_ising function from ising.py
 
-def calculate_and_save_values(lattice, Msamp,Esamp,num_analysis,index,temp,data_filename,corr_filename):
+
+def calculate_and_save_values(lattice, Msamp, Esamp, num_analysis, index, temp,
+                              data_filename, corr_filename):
 
     try:
         #calculate statistical values
@@ -18,11 +20,15 @@ def calculate_and_save_values(lattice, Msamp,Esamp,num_analysis,index,temp,data_
         E_mean = np.average(Esamp[-num_analysis:])
         M_std = np.std(Msamp[-num_analysis:])
         E_std = np.std(Esamp[-num_analysis:])
-        data_array = [np.abs(M_mean),M_std,E_mean,E_std]
-    
+        data_array = [np.abs(M_mean), M_std, E_mean, E_std]
+
         #write data to CSV file
-        header_array = ['Temperature','Magnetizatio n Mean','Magnetization Std Dev','Energy Mean','Energy Std Dev']
-        append_data_to_file(data_filename, header_array) if index == 0 else None
+        header_array = [
+            'Temperature', 'Magnetizatio n Mean', 'Magnetization Std Dev',
+            'Energy Mean', 'Energy Std Dev'
+        ]
+        append_data_to_file(data_filename,
+                            header_array) if index == 0 else None
         append_data_to_file(data_filename, data_array, temp)
 
         #get correlation function
@@ -30,35 +36,75 @@ def calculate_and_save_values(lattice, Msamp,Esamp,num_analysis,index,temp,data_
         corr = lattice.calc_auto_correlation()
 
         #write correlation function to CSV file
-        header_array = ['Temperature','K','Spatial Spin Correlation']
-        append_data_to_file(corr_filename, header_array) if index == 0 else None
-        [append_data_to_file(corr_filename, corr_value, temp) for corr_value in corr]
+        header_array = ['Temperature', 'K', 'Spatial Spin Correlation']
+        append_data_to_file(corr_filename,
+                            header_array) if index == 0 else None
+        [
+            append_data_to_file(corr_filename, corr_value, temp)
+            for corr_value in corr
+        ]
 
         return True
 
     except:
-        logging.error("Temp="+str(temp)+": Statistical Calculation Failed. No Data Written.")
+        logging.error("Temp=" + str(temp) +
+                      ": Statistical Calculation Failed. No Data Written.")
         return False
+
 
 #simulation options (enter python main.py --help for details)
 @click.command()
-@click.option('--t_min', default=2.0, prompt='Minimum Temp', help='Minimum Temperature (inclusive)', type=float)
-@click.option('--t_max', default=2.6, prompt='Maximum Temp', help='Maximum Temperature (inclusive)', type=float)
-@click.option('--t_step', default=0.1, prompt='Temp Step Size', help='Temperature Step Size', type=float)
-
-@click.option('--n', prompt='Lattice Size', help='Lattice Size (NxN)',type=int)
-@click.option('--num_steps', default=100000, help='Total Number of Steps',type=int)
-@click.option('--num_analysis', default=50000, help='Number of Steps used in Analysis',type=int)
-@click.option('--num_burnin', default=25000, help='Total Number of Burnin Steps',type=int)
-
-@click.option('--j', default=1.0, help='Interaction Strength',type=float)
-@click.option('--b', default=0.0, help='Applied Magnetic Field',type=float)
-@click.option('--flip_prop', default=0.1, help='Proportion of Spins to Consider Flipping per Step',type=float)
-
-@click.option('--output', default='data', help='Directory Name for Data Output',type=str)
-@click.option('--plots', default=True, help='Turn Automatic Plot Creation Off or On',type=bool)
-
-def run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,flip_prop,output,plots):
+@click.option(
+    '--t_min',
+    default=2.0,
+    prompt='Minimum Temp',
+    help='Minimum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_max',
+    default=2.6,
+    prompt='Maximum Temp',
+    help='Maximum Temperature (inclusive)',
+    type=float)
+@click.option(
+    '--t_step',
+    default=0.1,
+    prompt='Temp Step Size',
+    help='Temperature Step Size',
+    type=float)
+@click.option(
+    '--n', prompt='Lattice Size', help='Lattice Size (NxN)', type=int)
+@click.option(
+    '--num_steps', default=100000, help='Total Number of Steps', type=int)
+@click.option(
+    '--num_analysis',
+    default=50000,
+    help='Number of Steps used in Analysis',
+    type=int)
+@click.option(
+    '--num_burnin',
+    default=25000,
+    help='Total Number of Burnin Steps',
+    type=int)
+@click.option('--j', default=1.0, help='Interaction Strength', type=float)
+@click.option('--b', default=0.0, help='Applied Magnetic Field', type=float)
+@click.option(
+    '--flip_prop',
+    default=0.1,
+    help='Proportion of Spins to Consider Flipping per Step',
+    type=float)
+@click.option(
+    '--output',
+    default='data',
+    help='Directory Name for Data Output',
+    type=str)
+@click.option(
+    '--plots',
+    default=True,
+    help='Turn Automatic Plot Creation Off or On',
+    type=bool)
+def run_simulation(t_min, t_max, t_step, n, num_steps, num_analysis,
+                   num_burnin, j, b, flip_prop, output, plots):
 
     time_start = time.time()
 
@@ -71,28 +117,34 @@ def run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,fl
 
     data_filename, corr_filename = get_filenames(output)
 
-    write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop)
+    write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop)
 
     if plots:
         #initialize vars for plotting values
         temp_arr, M_mean_arr, E_mean_arr, M_std_arr, E_std_arr = [],[],[],[],[]
 
-    print('\nSimulation Started! Data will be written to ' + data_filename + '\n')
+    print('\nSimulation Started! Data will be written to ' + data_filename +
+          '\n')
 
-    temp_range = tqdm(T) #set fancy progress bar range
+    temp_range = tqdm(T)  #set fancy progress bar range
     for index, temp in enumerate(temp_range):
 
         #show current temperature
-        temp_range.set_description("Simulation Progress");
+        temp_range.set_description("Simulation Progress")
 
         try:
             #run the Ising model
-            Msamp, Esamp = run_ising(lattice, temp,num_steps,num_burnin,j,b)
+            Msamp, Esamp = run_ising(lattice, temp, num_steps, num_burnin, j,
+                                     b)
             #get and save statistical values
-            if calculate_and_save_values(lattice, Msamp,Esamp,num_analysis,index,temp,data_filename,corr_filename):
+            if calculate_and_save_values(lattice, Msamp, Esamp, num_analysis,
+                                         index, temp, data_filename,
+                                         corr_filename):
                 if plots:
                     #for plotting
-                    M_mean, E_mean, M_std, E_std = get_plot_values(temp,Msamp,Esamp,num_analysis)
+                    M_mean, E_mean, M_std, E_std = get_plot_values(
+                        temp, Msamp, Esamp, num_analysis)
                     temp_arr.append(temp)
                     M_mean_arr.append(M_mean)
                     E_mean_arr.append(E_mean)
@@ -104,17 +156,20 @@ def run_simulation(t_min,t_max,t_step,n,num_steps,num_analysis,num_burnin,j,b,fl
             sys.exit()
 
         except:
-            logging.error("Temp="+str(temp)+": Simulation Failed. No Data Written")
+            logging.error(
+                "Temp=" + str(temp) + ": Simulation Failed. No Data Written")
 
-
-    print('\n ------ Time start(%f) Time finished(%f), total time(%f)'%(time_start, time.time(), time.time()-time_start))
-    print('\n\nSimulation Finished! Data written to '+ data_filename)
+    print('\n ------ Time start(%f) Time finished(%f), total time(%f)' %
+          (time_start, time.time(), time.time() - time_start))
+    print('\n\nSimulation Finished! Data written to ' + data_filename)
 
     lattice.free_memory()
     if plots:
         plot_graphs(temp_arr, M_mean_arr, M_std_arr, E_mean_arr, E_std_arr)
 
-def get_plot_values(temp,Msamp,Esamp,num_analysis): #only for plotting at end
+
+def get_plot_values(temp, Msamp, Esamp,
+                    num_analysis):  #only for plotting at end
     try:
         M_mean = np.average(Msamp[-num_analysis:])
         E_mean = np.average(Esamp[-num_analysis:])
@@ -125,10 +180,18 @@ def get_plot_values(temp,Msamp,Esamp,num_analysis): #only for plotting at end
         logging.error("Temp={0}: Error getting plot values".format(temp))
         return False
 
-def plot_graphs(temp_arr,M_mean_arr,M_std_arr,E_mean_arr,E_std_arr): #plot graphs at end
+
+def plot_graphs(temp_arr, M_mean_arr, M_std_arr, E_mean_arr,
+                E_std_arr):  #plot graphs at end
     plt.figure(1)
-    plt.ylim(0,1)
-    plt.errorbar(temp_arr, np.absolute(M_mean_arr), yerr=M_std_arr, uplims=True, lolims=True,fmt='o')
+    plt.ylim(0, 1)
+    plt.errorbar(
+        temp_arr,
+        np.absolute(M_mean_arr),
+        yerr=M_std_arr,
+        uplims=True,
+        lolims=True,
+        fmt='o')
     plt.xlabel('Temperature')
     plt.ylabel('Magnetization')
     plt.figure(2)
@@ -137,67 +200,95 @@ def plot_graphs(temp_arr,M_mean_arr,M_std_arr,E_mean_arr,E_std_arr): #plot graph
     plt.ylabel('Energy')
     plt.show()
 
-def check_step_values(num_steps,num_analysis,num_burnin): #simulation size checks and exceptions
+
+def check_step_values(num_steps, num_analysis,
+                      num_burnin):  #simulation size checks and exceptions
     if (num_burnin > num_steps):
-        raise ValueError('num_burning cannot be greater than available num_steps. Exiting simulation.')
+        raise ValueError(
+            'num_burning cannot be greater than available num_steps. Exiting simulation.'
+        )
         sys.exit()
 
     if (num_analysis > num_steps - num_burnin):
-        raise ValueError('num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.')
+        raise ValueError(
+            'num_analysis cannot be greater than available num_steps after burnin. Exiting simulation.'
+        )
         sys.exit()
 
-def get_filenames(dirname): #make data folder if doesn't exist, then specify filename
+
+def get_filenames(
+        dirname):  #make data folder if doesn't exist, then specify filename
     try:
         if not os.path.exists(dirname):
             os.makedirs(dirname)
-        data_filename = os.path.join(dirname,'data_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
-        corr_filename = os.path.join(dirname,'corr_'+str(time.strftime("%Y%m%d-%H%M%S"))+".csv")
+        data_filename = os.path.join(
+            dirname, 'data_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
+        corr_filename = os.path.join(
+            dirname, 'corr_' + str(time.strftime("%Y%m%d-%H%M%S")) + ".csv")
         #Write simulation parameters to file
         return data_filename, corr_filename
     except:
         raise ValueError('Directory name not valid. Exiting simulation.')
         sys.exit()
 
-def write_sim_parameters(data_filename,corr_filename,n,num_steps,num_analysis,num_burnin,j,b,flip_prop):
+
+def write_sim_parameters(data_filename, corr_filename, n, num_steps,
+                         num_analysis, num_burnin, j, b, flip_prop):
     try:
-        with open(data_filename,'w') as csv_file:
+        with open(data_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             #Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
-        with open(corr_filename,'w') as csv_file:
+        with open(corr_filename, 'w') as csv_file:
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             #Write simulations parameters to CSV file
-            writer.writerow(['Lattice Size (NxN)','Total Steps','Steps Used in Analysis','Burnin Steps','Interaction Strength','Applied Mag Field','Spin Prop'])
-            writer.writerow([n,num_steps,num_analysis,num_burnin,j,b,flip_prop])
+            writer.writerow([
+                'Lattice Size (NxN)', 'Total Steps', 'Steps Used in Analysis',
+                'Burnin Steps', 'Interaction Strength', 'Applied Mag Field',
+                'Spin Prop'
+            ])
+            writer.writerow(
+                [n, num_steps, num_analysis, num_burnin, j, b, flip_prop])
             writer.writerow([])
     except:
-        logging.error('Could not save simulation parameters. Exiting simulation')
+        logging.error(
+            'Could not save simulation parameters. Exiting simulation')
         sys.exit()
 
-def get_temp_array(t_min,t_max,t_step):
+
+def get_temp_array(t_min, t_max, t_step):
     if (t_min > t_max):
-        raise ValueError('T_min cannot be greater than T_max. Exiting Simulation')
+        raise ValueError(
+            'T_min cannot be greater than T_max. Exiting Simulation')
         sys.exit()
     try:
-        T = np.arange(t_min,t_max,t_step).tolist()
+        T = np.arange(t_min, t_max, t_step).tolist()
         return T
     except:
-        raise ValueError('Error creating temperature array. Exiting simulation.')
+        raise ValueError(
+            'Error creating temperature array. Exiting simulation.')
         sys.exit()
 
-def append_data_to_file(filename,data_array,temp=False):
+
+def append_data_to_file(filename, data_array, temp=False):
     try:
-        with open(filename,'a') as csv_file: #appends to existing CSV File
+        with open(filename, 'a') as csv_file:  #appends to existing CSV File
             writer = csv.writer(csv_file, delimiter=',', lineterminator='\n')
             if temp:
-                writer.writerow([temp]+data_array)
+                writer.writerow([temp] + data_array)
             else:
                 writer.writerow(data_array)
 
     except:
         logging.error("Temp={0}: Error Writing to File".format(temp))
+
 
 if __name__ == "__main__":
     print("\n2D Ising Model Simulation\n")


### PR DESCRIPTION
Here is a possible alternate implementation of the multiprocessing code that should not drop temperature steps. It has the distinct disadvantage of storing all the data from each run in main memory before writing it to disk once all temperatures are finished. However, I think that there may be some advantages to using `multiprocessing.Pool.map` with a `partial()`-frozen version of the simulation function in terms of code readability, performance, and stability (i.e. not dropping temperatures). I think it should be possible to add the real-time saving back to this variant. If I recall correctly, using the `logging` module may be the most stable way to do so.

In addition, the temperature list is now constructed with an admittedly more verbose pure Python expression rather than `numpy.arange`, but should not have the floating point round-off issues that `arange` exhibits (From `https://docs.scipy.org/doc/numpy/reference/generated/numpy.arange.html`: _"When using a non-integer step, such as 0.1, the results will often not be consistent. It is better to use linspace for these cases."_)